### PR TITLE
Fix order submit action

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "react-challenge-project-sep-trial",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Fixed `event.target.value`

## Purpose
So the order submit action is functional.

## Approach
Added missing `target` to `event.target.value`

## Testing Steps
Pull down app
navigate to order-form
place order
navigate to view orders and observe if order has been submitted

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #1
