### PR TITLE
Time formatting fix

### DIFF
--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,32 +1,43 @@
-import React from 'react';
+import React from "react";
 
 const OrdersList = (props) => {
-    const { orders } = props;
-    if (!props || !props.orders || !props.orders.length) return (
-        <div className="empty-orders">
-            <h2>There are no orders to display</h2>
-        </div>
+  const { orders } = props;
+  if (!props || !props.orders || !props.orders.length)
+    return (
+      <div className="empty-orders">
+        <h2>There are no orders to display</h2>
+      </div>
     );
 
-    return orders.map(order => {
-        const createdDate = new Date(order.createdAt);
-        return (
-            <div className="row view-order-container" key={order._id}>
-                <div className="col-md-4 view-order-left-col p-3">
-                    <h2>{order.order_item}</h2>
-                    <p>Ordered by: {order.ordered_by || ''}</p>
-                </div>
-                <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
-                    <p>Quantity: {order.quantity}</p>
-                </div>
-                <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
-                </div>
-            </div>
-        );
-    });
-}
+  const orderedTime = (time) => {
+    const timeFormat = {
+      hour: time.getHours() % 12 || 12,
+      minute: time.getMinutes().toString().padStart(2, "0"),
+      seconds: time.getSeconds().toString().padStart(2, "0"),
+      amOrPm: time.getHours() < 12 ? "am" : "pm",
+    };
+    return `${timeFormat.hour}:${timeFormat.minute}:${timeFormat.seconds}${timeFormat.amOrPm}`;
+  };
+
+  return orders.map((order) => {
+    const createdDate = new Date(order.createdAt);
+    return (
+      <div className="row view-order-container" key={order._id}>
+        <div className="col-md-4 view-order-left-col p-3">
+          <h2>{order.order_item}</h2>
+          <p>Ordered by: {order.ordered_by || ""}</p>
+        </div>
+        <div className="col-md-4 d-flex view-order-middle-col">
+          <p>Order placed at {orderedTime(createdDate)}</p>
+          <p>Quantity: {order.quantity}</p>
+        </div>
+        <div className="col-md-4 view-order-right-col">
+          <button className="btn btn-success">Edit</button>
+          <button className="btn btn-danger">Delete</button>
+        </div>
+      </div>
+    );
+  });
+};
 
 export default OrdersList;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Created `orderedTime` function to to get correctly formatted order time.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
Ordered time displayed time without 0 padding on a 24 hour clock.

## Approach
Time cycle is now a 12 hour clock with zero padding for minutes and seconds.

## Testing Steps
Place an order
Observe placed order time under View Orders tab.

## Learning
Researched `padStart` for adding `0` for minutes and seconds when time only has one digit.

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes Issue 2
