### PR TITLE
Adds logged in user email to template header

### DIFF
--- a/application/src/components/common/template.css
+++ b/application/src/components/common/template.css
@@ -1,24 +1,30 @@
 .bg-layer {
-    background: #7A5114;
-    min-height: 100vh;
-    width: 100%;
+  background: #7a5114;
+  min-height: 100vh;
+  width: 100%;
 }
 
 .fg-layer {
-    background: #ECEAEA;
-    min-height: 100vh;
-    margin-left: 20%;
-    margin-right: 20%;
+  background: #eceaea;
+  min-height: 100vh;
+  margin-left: 20%;
+  margin-right: 20%;
 }
 
 .logo {
-    display: block;
-    font-family: "Optima";
-    font-size: 4em;
-    padding-left: 20%;
-    padding-right: 20%;
-    padding-top: 5%;
-    text-align: center;
-    text-decoration: underline;
-    text-decoration-color: #A43F3F;
+  display: block;
+  font-family: "Optima";
+  font-size: 4em;
+  padding-left: 20%;
+  padding-right: 20%;
+  padding-top: 5%;
+  text-align: center;
+  text-decoration: underline;
+  text-decoration-color: #a43f3f;
+}
+
+.user {
+  text-align: right;
+  padding: 8px 15px 0 0;
+  font-family: "Optima", serif;
 }

--- a/application/src/components/common/template.js
+++ b/application/src/components/common/template.js
@@ -1,17 +1,21 @@
-import React from 'react';
-import { Nav } from '../../components';
-import './template.css';
+import React from "react";
+import { Nav } from "../../components";
+import { useSelector } from "react-redux";
+import "./template.css";
 
-const Template = props => {
-    return (
-        <div className="bg-layer">
-            <div className="fg-layer">
-                <label className="logo">Bruce's Diner</label>
-                <Nav />
-                {props.children}
-            </div>
-        </div>
-    );
-}
+const Template = (props) => {
+    const user = useSelector((state) => state.login.email);
+
+  return (
+    <div className="bg-layer">
+      <div className="fg-layer">
+        <p className='user'>Hello, {user}</p>
+        <label className="logo">Bruce's Diner</label>
+        <Nav />
+        {props.children}
+      </div>
+    </div>
+  );
+};
 
 export default Template;


### PR DESCRIPTION
## Changes
1. `useSelector` to bring in logged in user email to template.js from redux.
2. Render user email to header in template.js.

## Purpose
Login status indicator

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #18 (challenge task 10)
